### PR TITLE
Fix extra unused argument to (Main) constructor

### DIFF
--- a/bench/main.hvm
+++ b/bench/main.hvm
@@ -76,4 +76,4 @@
 // Strict constructors
 (BOTH !a !b) = (Both a b)
 
-(Main n) = (Sum (Sort (Reverse (Gen 22))))
+(Main) = (Sum (Sort (Reverse (Gen 22))))


### PR DESCRIPTION
The `(Main n)` constructor expects one argument, but apparently, the command-line given on the example benchmark does not supply that argument. This results in a `panic` that looks like this (issue #7):

```
% time cargo run --release -- run -s 134217728 -t 12
    Finished release [optimized] target(s) in 0.05s
     Running `target/release/main run -s 134217728 -t 12`
thread 'main' panicked at 'inconsistent arity on: '(Main)'', src/language/rulebook.rs:95:15
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
cargo run --release -- run -s 134217728 -t 12  0.08s user 0.02s system 99% cpu 0.105 total
```

With this fix, the program runs to completion.

Signed-off-by: Christophe de Dinechin <christophe@dinechin.org>